### PR TITLE
Add support for Claude 3.5 Sonnet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@logicleai/llmosaic",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@logicleai/llmosaic",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.20.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logicleai/llmosaic",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "JavaScript toolkit for calling LLM APIs in OpenAI format",
   "main": "dist/index.js",
   "scripts": {

--- a/src/providers/anthropic/models.ts
+++ b/src/providers/anthropic/models.ts
@@ -2,8 +2,26 @@ import { EnrichedModel } from '../../types';
 
 export const modelEnrichmentData:EnrichedModel[] = [
   {
+    name: 'Claude 3.5 Sonnet',
+    description: 'Most intelligent model yet',
+    id: 'claude-3-5-sonnet-20240620',
+    object: 'model',
+    created: 1698959748,
+    owned_by: 'anthropic',
+    context_length: 200000,
+    tokenizer: 'anthropic',
+    capabilities: {
+      vision: true,
+      function_calling: true
+    },
+    prices: {
+      input: 3,
+      output: 15
+    }
+  },
+  {
     name: 'Claude 3 Opus',
-    description: 'Most powerful model for highly complex tasks',
+    description: 'Powerful model for highly complex tasks',
     id: 'claude-3-opus-20240229',
     object: 'model',
     created: 1698959748,
@@ -21,7 +39,7 @@ export const modelEnrichmentData:EnrichedModel[] = [
   },
   {
     name: 'Claude 3 Sonnet',
-    description: 'Ideal balance of intelligence and speed for enterprise workloads',
+    description: 'Balance of intelligence and speed',
     id: 'claude-3-sonnet-20240229',
     object: 'model',
     created: 1698959748,

--- a/src/providers/logicle/models.ts
+++ b/src/providers/logicle/models.ts
@@ -38,8 +38,26 @@ export const modelEnrichmentData:EnrichedModel[] = [
     }
   },
   {
+    name: 'Claude 3.5 Sonnet',
+    description: 'Most intelligent model yet',
+    id: 'claude-3-5-sonnet-20240620',
+    object: 'model',
+    created: 1698959748,
+    owned_by: 'anthropic',
+    context_length: 200000,
+    tokenizer: 'anthropic',
+    capabilities: {
+      vision: true,
+      function_calling: true
+    },
+    prices: {
+      input: 3,
+      output: 15
+    }
+  },
+  {
     name: 'Claude 3 Opus',
-    description: 'Most powerful model for highly complex tasks',
+    description: 'Powerful model for highly complex tasks',
     id: 'claude-3-opus',
     object: 'model',
     created: 1698959748,
@@ -57,7 +75,7 @@ export const modelEnrichmentData:EnrichedModel[] = [
   },
   {
     name: 'Claude 3 Sonnet',
-    description: 'Ideal balance of intelligence and speed for enterprise workloads',
+    description: 'Balance of intelligence and speed',
     id: 'claude-3-sonnet',
     object: 'model',
     created: 1698959748,
@@ -89,6 +107,60 @@ export const modelEnrichmentData:EnrichedModel[] = [
     prices: {
       input: 0.25,
       output: 1.25
+    }
+  },
+  {
+    name: 'Claude 2.1',
+    description: 'Updated version of Claude 2 with improved accuracy',
+    id: 'claude-2.1',
+    object: 'model',
+    created: 1698959748,
+    owned_by: 'anthropic',
+    context_length: 200000,
+    tokenizer: 'anthropic',
+    capabilities: {
+      vision: false,
+      function_calling: false
+    },
+    prices: {
+      input: 8,
+      output: 24
+    }
+  },
+  {
+    name: 'Claude 2',
+    description: 'Predecessor to Claude 3, offering strong all-round performance',
+    id: 'claude-2.0',
+    object: 'model',
+    created: 1698959748,
+    owned_by: 'anthropic',
+    context_length: 100000,
+    tokenizer: 'anthropic',
+    capabilities: {
+      vision: false,
+      function_calling: false
+    },
+    prices: {
+      input: 8,
+      output: 24
+    }
+  },
+  {
+    name: 'Claude Instant 1.2',
+    description: 'Our cheapest small and fast model, a predecessor of Claude Haiku.',
+    id: 'claude-instant-1.2',
+    object: 'model',
+    created: 1698959748,
+    owned_by: 'anthropic',
+    context_length: 100000,
+    tokenizer: 'anthropic',
+    capabilities: {
+      vision: false,
+      function_calling: false
+    },
+    prices: {
+      input: 0.8,
+      output: 2.4
     }
   }
 ];


### PR DESCRIPTION
In this PR:
- Added support for Anthropic Claude 3.5 Sonnet (available on both Anthropic and Logicle Cloud providers).